### PR TITLE
ghc 9.4: bump base, monad-logger-aeson

### DIFF
--- a/slacker.cabal
+++ b/slacker.cabal
@@ -62,14 +62,14 @@ library
     Slacker.Util
   build-depends:
     aeson                         >= 2.0.3 && < 2.2,
-    base                          >= 4.14.3 && < 4.17,
+    base                          >= 4.14.3 && < 4.18,
     dlist                         >= 1.0 && < 1.1,
     exceptions                    >= 0.10.4 && < 0.11,
     http-client                   >= 0.7.11 && < 0.8,
     http-conduit                  >= 2.3.8 && < 2.4,
     microlens                     >= 0.4.12 && < 0.5,
     microlens-aeson               >= 2.4 && < 2.6,
-    monad-logger-aeson            >= 0.2.0 && < 0.4,
+    monad-logger-aeson            >= 0.2.0 && < 0.5,
     network-uri                   >= 2.6.4 && < 2.7,
     stm-chans                     >= 3.0.0 && < 3.1,
     text                          >= 1.2.4 && < 3.0,


### PR DESCRIPTION
Naive version bump, makes it build with ghc 9.4 (built from this branch with nix: https://github.com/srhb/slacker/tree/flake)

I tried going all the way to ghc 9.6, but that won't work until world-peace is compatible with 9.6, and possibly other deps as well. :smile_cat: 